### PR TITLE
Force Buttons Layout

### DIFF
--- a/styles/android/pickerView.tss
+++ b/styles/android/pickerView.tss
@@ -22,7 +22,8 @@
   bottom: '5%',
   height: 50,
   backgroundColor: 'transparent',
-  width: Ti.UI.FILL
+  width: Ti.UI.FILL,
+  layout: 'composite'
 }
 
 "Button": {


### PR DESCRIPTION
Android could not render Done Button in some case.
Some Android does not show the Done button correctly.
Once add "layout: 'composite'" it force the view to render properly. 