### PR TITLE
Update widget.js

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -91,8 +91,10 @@ function populateOptionsDialog() {
   optionsDialog = Ti.UI.createOptionDialog({
     options: pickerData,
     buttonNames: ['Cancel'],
-    selectedIndex: selectedIndex
   });
+  if (selectedIndex) {
+  	optionsDialog.selectedIndex = selectedIndex;
+  }
   optionsDialog.show();
   optionsDialog.addEventListener('click', done);
 }
@@ -200,7 +202,6 @@ function getSelectedRowTitle(index) {
 */
 function getKeyIndexFromPairs(pairs, key) {
   pairs = pairs || [];
-  key = key || null;
   var rowIndex = null;
 
   // Determine index.


### PR DESCRIPTION
Fixes two Android bugs:
1. Able to find keys that are 0
2. Will not crash if you pass in a selectedValue that doesn't match your keys
